### PR TITLE
get_bdev Function

### DIFF
--- a/include/sys/vdev_disk.h
+++ b/include/sys/vdev_disk.h
@@ -45,6 +45,7 @@
 #include <sys/vdev.h>
 
 #ifdef __linux__
+struct block_device *get_bdev(void *tsd);
 int __vdev_classic_physio(struct block_device *bdev, zio_t *zio,
     size_t io_size, uint64_t io_offset, int rw, int flags);
 int vdev_disk_io_flush(struct block_device *bdev, zio_t *zio);

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -124,6 +124,12 @@ typedef fmode_t vdev_bdev_mode_t;
 #define	VDEV_BDEV_MODE_MASK	(FMODE_READ|FMODE_WRITE|FMODE_EXCL)
 #endif
 
+struct block_device *
+get_bdev(void *tsd)
+{
+	return (BDH_BDEV(((vdev_disk_t *)tsd)->vd_bdh));
+}
+
 static vdev_bdev_mode_t
 vdev_bdev_mode(spa_mode_t smode)
 {


### PR DESCRIPTION
Adds a function that returns the
correct block device handle from
the vdev_disk_t struct defined
in vdev_disk.c.

The purpose of this addition is
to use this function to get the
block device handle to pass to
zia_disk_open from zia_open_vdevs,
which currently just casts a
vdev_disk_t object to a block device *,
leading to failure if the operation
does not fallback.
