### PR TITLE
Fixed assertion in Z.I.A.

### DIFF
--- a/module/zfs/zia.c
+++ b/module/zfs/zia.c
@@ -296,8 +296,6 @@ zia_fini(void)
 static void zia_open_vdevs_impl(vdev_t *vd) {
 	vdev_ops_t *ops = vd->vdev_ops;
 	if (ops->vdev_op_leaf) {
-		ASSERT(!vd->vdev_zia_handle);
-
 		const size_t len = strlen(ops->vdev_op_type);
 		if (len == 4) {
 			if (memcmp(ops->vdev_op_type, "file", 4) == 0) {


### PR DESCRIPTION
Removed an assertion in zia_open_vdevs
that led to a failure in an edge case
where disk_write and file_write were
both enabled.
