### PR TITLE
Z.I.A. Tests and Provider Disabling

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -9812,6 +9812,13 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			break;
 		case ZPOOL_PROP_ZIA_PROVIDER:
 			strval = fnvpair_value_string(elem);
+			if (strncmp(strval, "NULL", 5) == 0 ||
+			    strncmp(strval, "off", 4) == 0) {
+				zia_put_provider(&zia_props->provider,
+				    spa->spa_root_vdev);
+				break;
+			}
+
 			if (zia_props->provider != NULL)
 				zia_put_provider(&zia_props->provider,
 				    spa->spa_root_vdev);

--- a/module/zfs/zia.c
+++ b/module/zfs/zia.c
@@ -962,7 +962,7 @@ zia_compress(zia_props_t *props, enum zio_compress c,
     uint8_t level, boolean_t *local_offload)
 {
 #ifdef ZIA
-	if (!dpusm) {
+	if (!dpusm || !props->provider) {
 		return (ZIA_FALLBACK);
 	}
 
@@ -1219,6 +1219,9 @@ zia_raidz_alloc(zio_t *zio, raidz_row_t *rr, boolean_t rec,
 	}
 
 	zia_props_t *props = zia_get_props(zio->io_spa);
+	if (!props->provider) {
+		return (ZIA_FALLBACK);
+	}
 
 	/* get column sizes */
 	const size_t column_sizes_size = sizeof (size_t) * rr->rr_cols;

--- a/tests/zfs-tests/tests/functional/zia/zia.kshlib
+++ b/tests/zfs-tests/tests/functional/zia/zia.kshlib
@@ -47,7 +47,10 @@ function dpusm_loaded
     then
         lsmod | grep dpusm > /dev/null
         ret="$?"
-        (( "${ret}" != "0" )) && log_unsupported "dpusm not loaded"
+        if [[ "${ret}" != "0" ]]
+        then
+            log_unsupported "dpusm not loaded"
+        fi
     fi
 }
 
@@ -63,7 +66,7 @@ function load_provider
     if [[ "$(zia_available)" == "yes" ]]
     then
         log_must insmod "${SBIN_DIR}/module/${PROVIDER}.ko"
-        log_must zpool set zia_provider="${PROVIDER}" "${TESTPOOL}"
+        log_must zpool set zia_provider="${PROVIDER_MODULE}" "${TESTPOOL}"
     fi
 }
 
@@ -71,7 +74,7 @@ function unload_provider
 {
     if [[ "$(zia_available)" == "yes" ]]
     then
-        log_must zpool set zia_provider="" "${TESTPOOL}"
+        log_must zpool set zia_provider="NULL" "${TESTPOOL}"
         log_must rmmod "${PROVIDER_MODULE}"
     fi
 }


### PR DESCRIPTION
Fixed Z.I.A. testing logic so that all
available tests run as expected. At
the time of this commit, all tests pass.

Additionally, support for unassigning
zia_provider was added. Usage:
zpool set zia_provider=<off/NULL> <pool>
This change was required for one aspect
of Z.I.A. testing.